### PR TITLE
Add support for staircase light switch

### DIFF
--- a/types/LightBulb.js
+++ b/types/LightBulb.js
@@ -9,6 +9,7 @@ var Service, Characteristic;
  *  * Dimmer
  *  * Dimmer-%
  *  * RGB
+ *  * StairwayLS
  *
  * @param config
  * @param platform
@@ -71,6 +72,9 @@ LoxoneLightbulb.prototype._setValue = function(on, callback) {
     var accessory = this;
 
     var command = on ? "On": "Off";
+    if (accessory.type == 'StairwayLS' && on) {
+        command = "pulse";
+    }
 
     loxone.set(input, command, function(value) {
         if (value == undefined) {


### PR DESCRIPTION
According to the loxone documentation at http://www.loxone.com/enen/service/documentation/api/structure-file.html you have a third command for stairware light switches and this is pulse, this will set the timer and when the time expires the lights will automatically turn of. When using the on command the lights will stay on untill sending the off command.
